### PR TITLE
docker 不支持UNLESS-STOP属性，修改为unless-stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 reliable-master:
   container_name: "reliable-master"
-  restart: "UNLESS-STOP"
+  restart: "unless-stopped"
   image: reliable-master
   ports:
     - "${RELIABLE_MASTER_PORT}:${RELIABLE_MASTER_PORT}"


### PR DESCRIPTION
docker 不支持UNLESS-STOP属性，修改为unless-stopped，https://docs.docker.com/engine/reference/run/#restart-policies-restart